### PR TITLE
fix(tls): prevent crash when altNames in cert are not strings

### DIFF
--- a/src/tls/tls-utils.ts
+++ b/src/tls/tls-utils.ts
@@ -252,7 +252,11 @@ export class TlsUtils {
   }
 
   public static isMappingHostName(DNSName: string, hostname: string): boolean {
-    let reg = DNSName.replace(/\./g, '\\.').replace(/\*/g, '[^.]+');
+    const value = typeof DNSName === 'string' ? DNSName : DNSName?.value;
+    if (typeof value !== 'string') {
+        return false;
+    }
+    let reg = value.replace(/\./g, '\\.').replace(/\*/g, '[^.]+');
     reg = `^${reg}$`;
     return new RegExp(reg).test(hostname);
   }


### PR DESCRIPTION
🐛 Fix: TypeError in isMappingHostName for non-string DNS names

Description
This PR resolves a runtime error that occurs when the subjectAltName entries in a TLS certificate are objects instead of plain strings. The isMappingHostName() function was calling .replace() on these objects, leading to the following error:

TypeError: DNSName.replace is not a function

Changes
Added type checking in isMappingHostName() to extract .value safely and ensure it's a string before calling .replace().
Improved getMappingHostNamesFormCert() to filter and include only valid string values from altNames.
Why it matters
Without this fix, certain certificates cause the proxy to crash when intercepting HTTPS traffic due to incorrect handling of DNSName types in certificates.

How to test
Run the proxy server with SSL MITM enabled.
Visit a site with multiple or wildcard SANs in its cert.
Confirm no crash occurs and the traffic is intercepted correctly.