### PR TITLE
Fix: Prevent node-forge crash due to unsupported certificate subject attributes

### DIFF
--- a/src/tls/tls-utils.ts
+++ b/src/tls/tls-utils.ts
@@ -172,35 +172,42 @@ export class TlsUtils {
     caPair: CaPair,
     originCertificate: PeerCertificate,
   ): CaPair {
-    // const certificate = TlsUtils.covertNodeCertToForgeCert(originCertificate);
-
     const keys = forge.pki.rsa.generateKeyPair(2048);
     const cert = forge.pki.createCertificate();
     cert.publicKey = keys.publicKey;
-
+  
     cert.serialNumber = originCertificate.serialNumber;
     cert.validity.notBefore = new Date();
     cert.validity.notBefore.setFullYear(cert.validity.notBefore.getFullYear() - 1);
     cert.validity.notAfter = new Date();
     cert.validity.notAfter.setFullYear(cert.validity.notAfter.getFullYear() + 1);
-
+  
+    const supportedNames = [
+      'commonName', 'countryName', 'stateOrProvinceName',
+      'localityName', 'organizationName', 'organizationalUnitName',
+      'emailAddress',
+    ];
+  
+    const supportedShortNames = ['CN', 'C', 'ST', 'L', 'O', 'OU', 'E'];
+  
     const attrs: forge.pki.CertificateField[] = [];
-    Object.entries(originCertificate.subject).forEach(([name, value]) => {
-      attrs.push({
-        shortName: name,
-        value: value,
-      });
+    Object.entries(originCertificate.subject).forEach(([key, value]) => {
+      if (supportedNames.includes(key)) {
+        attrs.push({ name: key, value });
+      } else if (supportedShortNames.includes(key)) {
+        attrs.push({ shortName: key, value });
+      }
     });
-
+  
     cert.setSubject(attrs);
     cert.setIssuer(caPair.cert.subject.attributes);
-
-    const subjectAltNames = originCertificate.subjectaltname.split(', ').map((name) => ({
+  
+    const subjectAltNames = originCertificate.subjectaltname?.split(', ').map((name) => ({
       // 2 is DNS type
       type: 2,
       value: name.replace('DNS:', '').trim(),
-    }));
-
+    })) ?? [];
+  
     cert.setExtensions([
       {
         name: 'basicConstraints',
@@ -240,12 +247,12 @@ export class TlsUtils {
       },
     ]);
     cert.sign(caPair.key, forge.md.sha256.create());
-
+  
     return {
       key: keys.privateKey,
       cert: cert,
     };
-  }
+  }  
 
   public static isBrowserRequest(userAgent: string): boolean {
     return /mozilla/i.test(userAgent);


### PR DESCRIPTION
What this PR does
This PR adds a safeguard when creating fake certificates using the CA. Some real-world certificates include non-standard subject fields (like jurisdictionC, businessCategory, etc.) that node-forge doesn’t recognize. When setSubject() encounters these, it throws an error:

typescript
Copy
Edit
Error: Attribute type not specified.
This PR filters out any unsupported subject fields from the original certificate before passing them to forge, ensuring stable fake certificate generation.

Why it matters
This fixes runtime crashes when intercepting HTTPS requests with such certificates, improving reliability and compatibility of the proxy.

How it's done
Introduces a whitelist of supported name and shortName attributes.

Only those supported by node-forge are passed to cert.setSubject().

✅ Verified that it gracefully skips unknown fields and successfully creates a valid certificate.